### PR TITLE
fix: 🐛 incorrect file path when using default profile

### DIFF
--- a/profile.go
+++ b/profile.go
@@ -137,6 +137,10 @@ func Start(options ...func(*Profile) func(pkg *pkgprofile.Profile)) interface {
 		profile.region = "us-east-1"
 	}
 
+	if profile.localPath == "" {
+		profile.localPath = "/tmp/cpu.pprof"
+	}
+
 	profile.p = pkgprofile.Start(pkgOptions...)
 	return &profile
 }


### PR DESCRIPTION
## What?
Fix bug when not specifying explicitly any profile.

## Why?
Currently the profiling output fails to upload.
<img width="905" alt="image" src="https://github.com/jbleduigou/aws-lambda-profile/assets/1489214/18328f1c-dd7f-4777-8554-cfe7e2996e69">

## How?
Check for empty local path